### PR TITLE
Creating version 1.0.2

### DIFF
--- a/dotnet-sdk-airtime/src/main/Operation/BaseAirtimeOperation.cs
+++ b/dotnet-sdk-airtime/src/main/Operation/BaseAirtimeOperation.cs
@@ -72,8 +72,8 @@ namespace Reloadly.Airtime.Operation
             var accessToken = await RetrieveAccessTokenAsync();
 
             return new ReloadlyRequest<TResponse>(HttpMethod.Get, uri)
-                .AddHeader(HeaderNames.Accept, ReloadlyApiVersion.AirtimeV1)
-                .AddHeader(HeaderNames.Authorization, $"Bearer {accessToken}");
+                .SetHeader(HeaderNames.Accept, ReloadlyApiVersion.AirtimeV1)
+                .SetHeader(HeaderNames.Authorization, $"Bearer {accessToken}");
         }
 
         protected async Task<ReloadlyRequest<TResponse>> CreatePostRequestAsync<TResponse>(Uri uri, object body)
@@ -82,9 +82,9 @@ namespace Reloadly.Airtime.Operation
             var accessToken = await RetrieveAccessTokenAsync();
 
             return new ReloadlyRequest<TResponse>(HttpMethod.Post, uri)
-                .AddHeader(HeaderNames.Accept, ReloadlyApiVersion.AirtimeV1)
-                .AddHeader(HeaderNames.ContentType, MediaTypeNames.Application.Json)
-                .AddHeader(HeaderNames.Authorization, $"Bearer {accessToken}")
+                .SetHeader(HeaderNames.Accept, ReloadlyApiVersion.AirtimeV1)
+                .SetHeader(HeaderNames.ContentType, MediaTypeNames.Application.Json)
+                .SetHeader(HeaderNames.Authorization, $"Bearer {accessToken}")
                 .SetBody(body);
         }
 

--- a/dotnet-sdk-airtime/src/main/Reloadly.Airtime.csproj
+++ b/dotnet-sdk-airtime/src/main/Reloadly.Airtime.csproj
@@ -4,11 +4,11 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reloadly.Authentication" Version="1.0.1" />
+    <PackageReference Include="Reloadly.Authentication" Version="1.0.2" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-sdk-authentication/src/main/Operation/OAuth2Operation.cs
+++ b/dotnet-sdk-authentication/src/main/Operation/OAuth2Operation.cs
@@ -72,7 +72,7 @@ namespace Reloadly.Authentication.Operation
 
             request
                 .SetBody(requestBody)
-                .AddHeader(HeaderNames.Accept, MediaTypeNames.Application.Json);
+                .SetHeader(HeaderNames.Accept, MediaTypeNames.Application.Json);
 
             return _httpClient.SendAsync(request);
         }

--- a/dotnet-sdk-authentication/src/main/Reloadly.Authentication.csproj
+++ b/dotnet-sdk-authentication/src/main/Reloadly.Authentication.csproj
@@ -4,13 +4,13 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Reloadly.Core" Version="1.0.1" />
+    <PackageReference Include="Reloadly.Core" Version="1.0.2" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-sdk-core/src/main/Reloadly.Core/Reloadly.Core.csproj
+++ b/dotnet-sdk-core/src/main/Reloadly.Core/Reloadly.Core.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
+    <UserSecretsId>80b46c7e-c072-4f0a-8a3d-7e5627541015</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet-sdk-core/src/test/Reloadly.Core.Testing/Reloadly.Core.Testing.csproj
+++ b/dotnet-sdk-core/src/test/Reloadly.Core.Testing/Reloadly.Core.Testing.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="Reloadly.Core" Version="1.0.1" />
+    <PackageReference Include="Reloadly.Core" Version="1.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Changes

Creating version 1.0.2.

Fixes:
1. A bug where a rate limit response from the Reloadly API may cause two methods recursively calling each other.
2. A bug in the Core project where some query parameters would not be passed to the Airtime URLs in some cases.